### PR TITLE
Add embabel-agent-starter

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -14,10 +14,9 @@
 
     
     <dependencies>
-        <!-- Main Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-api</artifactId>
+            <artifactId>embabel-agent-starter</artifactId>
         </dependency>
 
         <dependency>

--- a/examples-java/src/main/java/com/embabel/example/AgentExampleApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentExampleApplication.java
@@ -18,20 +18,8 @@ package com.embabel.example;
 import com.embabel.common.util.WinUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-@SpringBootApplication(
-    scanBasePackages = {
-        "com.embabel.agent",
-        "com.embabel.template"
-    }
-)
-@ConfigurationPropertiesScan(
-    basePackages = {
-        "com.embabel.agent",
-        "com.embabel.template"
-    }
-)
+@SpringBootApplication
 public class AgentExampleApplication {
     
     static {

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -12,10 +12,10 @@
     <description>Agent Examples for Kotlin Developers</description>
 
     <dependencies>
-        <!-- Main Dependencies -->
+
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-api</artifactId>
+            <artifactId>embabel-agent-starter</artifactId>
         </dependency>
 
         <dependency>
@@ -24,7 +24,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Test Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test</artifactId>

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentExampleApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentExampleApplication.kt
@@ -17,21 +17,9 @@ package com.embabel.example
 
 import com.embabel.common.util.WinUtils
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
-@SpringBootApplication(
-    scanBasePackages = [
-        "com.embabel.agent",
-        "com.embabel.template",
-    ]
-)
-@ConfigurationPropertiesScan(
-    basePackages = [
-        "com.embabel.agent",
-        "com.embabel.template",
-    ]
-)
+@SpringBootApplication
 class AgentExampleApplication {
 
     companion object {

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/dogfood/research/Researcher.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/dogfood/research/Researcher.kt
@@ -23,9 +23,9 @@ import com.embabel.agent.config.models.OpenAiModels
 import com.embabel.agent.core.CoreToolGroups
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.ResearchReport
-import com.embabel.agent.prompt.Persona
 import com.embabel.agent.prompt.PromptUtils
 import com.embabel.agent.prompt.ResponseFormat
+import com.embabel.agent.prompt.persona.Persona
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.ModelProvider.Companion.CHEAPEST_ROLE
 import com.embabel.common.ai.model.ModelSelectionCriteria.Companion.byRole

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/movie/MovieFinder.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/movie/MovieFinder.kt
@@ -29,7 +29,7 @@ import com.embabel.agent.domain.library.Person
 import com.embabel.agent.domain.library.RelevantNewsStories
 import com.embabel.agent.domain.persistence.findOneFromContent
 import com.embabel.agent.event.ProgressUpdateEvent
-import com.embabel.agent.prompt.Persona
+import com.embabel.agent.prompt.persona.Persona
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.ModelSelectionCriteria.Companion.byName
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
This pull request refactors dependencies and annotations in the Java and Kotlin example projects to streamline configuration and improve package structure. Key changes include replacing dependencies in `pom.xml`, simplifying Spring Boot annotations, and updating import paths for the `Persona` class.

### Dependency Updates:
* Replaced `embabel-agent-api` with `embabel-agent-starter` in both `examples-java/pom.xml` and `examples-kotlin/pom.xml` to use a more comprehensive starter package. [[1]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201L17-R19) [[2]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L15-R18)
* Removed unnecessary comments for main and test dependencies in `examples-kotlin/pom.xml`.

### Annotation Simplifications:
* Simplified `@SpringBootApplication` annotations in `AgentExampleApplication` classes for both Java and Kotlin projects by removing `scanBasePackages` and `@ConfigurationPropertiesScan`. This reduces redundancy and leverages default Spring Boot behavior. [[1]](diffhunk://#diff-54452ac14e086213804716ac031e54c178538ae2d2bab4fd008592e4ccd62dffL21-R22) [[2]](diffhunk://#diff-9d6aa25f8d87c4675c2a308b64eec09f7a2a43e991e1cb2ca4fc04252caf3d05L20-R22)

### Import Path Updates:
* Updated import paths for the `Persona` class in Kotlin files to reflect its new location under `com.embabel.agent.prompt.persona`. This ensures compatibility with the updated package structure. [[1]](diffhunk://#diff-88e8e52025e23be39737ca07b07fbb512f74eecdf5838bca27a9a0f92e41f2efL26-R28) [[2]](diffhunk://#diff-fbb7d4d9b826972ae22b0cc648153b62dcabf3c3d10b3d9a37986eeae2be2375L32-R32)