### PR TITLE
Remove configuration properties scan.

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/AgentExampleApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentExampleApplication.java
@@ -15,20 +15,11 @@
  */
 package com.embabel.example;
 
-import com.embabel.common.util.WinUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class AgentExampleApplication {
-    
-    static {
-        if (WinUtils.IS_OS_WINDOWS()) {
-            // Set console to UTF-8 on Windows
-            // This is necessary to display non-ASCII characters correctly
-            WinUtils.CHCP_TO_UTF8();
-        }
-    }
     
     public static void main(String[] args) {
         SpringApplication.run(AgentExampleApplication.class, args);

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentExampleApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentExampleApplication.kt
@@ -15,23 +15,11 @@
  */
 package com.embabel.example
 
-import com.embabel.common.util.WinUtils
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class AgentExampleApplication {
-
-    companion object {
-        init {
-            if (WinUtils.IS_OS_WINDOWS()) {
-                // Set console to UTF-8 on Windows
-                // This is necessary to display non-ASCII characters correctly
-                WinUtils.CHCP_TO_UTF8()
-            }
-        }
-    }
-}
+class AgentExampleApplication
 
 fun main(args: Array<String>) {
     runApplication<AgentExampleApplication>(*args)


### PR DESCRIPTION
This pull request removes platform-specific initialization logic related to setting the console to UTF-8 on Windows in both the Java and Kotlin implementations of the `AgentExampleApplication`. This simplifies the application startup process.

### Removal of Windows-specific UTF-8 console setup:

* [`examples-java/src/main/java/com/embabel/example/AgentExampleApplication.java`](diffhunk://#diff-54452ac14e086213804716ac031e54c178538ae2d2bab4fd008592e4ccd62dffL18-L32): Removed the static block that used `WinUtils` to set the console to UTF-8 on Windows. The `WinUtils` import was also removed.
* [`examples-kotlin/src/main/kotlin/com/embabel/example/AgentExampleApplication.kt`](diffhunk://#diff-9d6aa25f8d87c4675c2a308b64eec09f7a2a43e991e1cb2ca4fc04252caf3d05L18-R22): Removed the companion object block that used `WinUtils` to set the console to UTF-8 on Windows. The `WinUtils` import was also removed.