### PR TITLE
Add loggingTheme starwars to Kotlin shell examples.

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java
@@ -20,7 +20,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.embabel.agent.config.annotation.EnableAgentMcp;
 
 @SpringBootApplication
-@EnableAgentMcp(loggingTheme="severance")
+@EnableAgentMcp(loggingTheme="starwars")
 public class AgentMcpApplication {
   
     public static void main(String[] args) {

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
@@ -20,7 +20,7 @@ import org.springframework.boot.runApplication
 import com.embabel.agent.config.annotation.EnableAgentShell
 
 @SpringBootApplication
-@EnableAgentShell
+@EnableAgentShell(loggingTheme="starwars")
 class AgentShellApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request updates the logging theme configuration for two example applications in the codebase. The changes ensure consistency in the logging theme by setting it to "starwars" for both applications.

Theme updates:

* [`examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java`](diffhunk://#diff-3e6f079302c5f8dbc8911dfb3fc3b0b3fe024edda5728ae2464101a0885ebf20L23-R23): Changed the `loggingTheme` parameter in the `@EnableAgentMcp` annotation from "severance" to "starwars".
* [`examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt`](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0L23-R23): Added the `loggingTheme` parameter to the `@EnableAgentShell` annotation and set it to "starwars".