### PR TITLE
Remove scripts referencing docker-desktop profile.

### DIFF
--- a/scripts/java/shell_docker.cmd
+++ b/scripts/java/shell_docker.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..\..\examples-java
-set MAVEN_PROFILE=enable-shell
-
-call ..\support\agent.bat
-
-endlocal

--- a/scripts/java/shell_docker.sh
+++ b/scripts/java/shell_docker.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=../../examples-java
-export MAVEN_PROFILE=enable-shell
-
-../support/agent.sh

--- a/scripts/kotlin/shell_docker.cmd
+++ b/scripts/kotlin/shell_docker.cmd
@@ -1,9 +1,0 @@
-@echo off
-setlocal
-
-set AGENT_APPLICATION=..\..\examples-kotlin
-set MAVEN_PROFILE=enable-shell
-
-call ..\support\agent.bat
-
-endlocal

--- a/scripts/kotlin/shell_docker.sh
+++ b/scripts/kotlin/shell_docker.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-export AGENT_APPLICATION=../../examples-kotlin
-export MAVEN_PROFILE=enable-shell
-
-../support/agent.sh


### PR DESCRIPTION
This pull request removes unused shell scripts related to Java and Kotlin projects. 
pending support for Docker Tools as part of Auto Configuration exercise.

Removed scripts for Java:

* [`scripts/java/shell_docker.cmd`](diffhunk://#diff-527d83c4988d76de6dd5396cec3a6ded856fb82d81bf6f90ee79d1c63fb21095L1-L9): Removed the Windows batch script for setting up the Java agent with Maven.
* [`scripts/java/shell_docker.sh`](diffhunk://#diff-78f9ede702aed5131966eecaf0e2021baab206f68ff0a1a3bf90943e6fe78063L1-L6): Removed the Bash script for setting up the Java agent with Maven.

Removed scripts for Kotlin:

* [`scripts/kotlin/shell_docker.cmd`](diffhunk://#diff-2270df97054ebd331e9c9b16c965976b4eab75f59225a3cfe4f0de4b1ca13d8aL1-L9): Removed the Windows batch script for setting up the Kotlin agent with Maven.
* [`scripts/kotlin/shell_docker.sh`](diffhunk://#diff-c324230e219b0461dc8bd8898a8e44ab67cd9f33eeabcef912b260d71859d91eL1-L6): Removed the Bash script for setting up the Kotlin agent with Maven.