### PR TITLE
Add LoggingTheme Enum.

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java
@@ -18,9 +18,10 @@ package com.embabel.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.embabel.agent.config.annotation.EnableAgentMcp;
+import com.embabel.agent.config.annotation.LoggingTheme;
 
 @SpringBootApplication
-@EnableAgentMcp(loggingTheme="starwars")
+@EnableAgentMcp
 public class AgentMcpApplication {
   
     public static void main(String[] args) {

--- a/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
@@ -18,9 +18,10 @@ package com.embabel.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.embabel.agent.config.annotation.EnableAgentShell;
+import com.embabel.agent.config.annotation.LoggingTheme;
 
 @SpringBootApplication
-@EnableAgentShell(loggingTheme="starwars")
+@EnableAgentShell(loggingTheme=LoggingTheme.STARWARS)
 public class AgentShellApplication {    
     
   public static void main(String[] args) {

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
@@ -18,9 +18,10 @@ package com.embabel.example
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import com.embabel.agent.config.annotation.EnableAgentShell
+import com.embabel.agent.config.annotation.LoggingTheme
 
 @SpringBootApplication
-@EnableAgentShell(loggingTheme="starwars")
+@EnableAgentShell(loggingTheme=LoggingTheme.STARWARS)
 class AgentShellApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request updates the usage of the `loggingTheme` attribute in the `EnableAgent` annotations across multiple files to improve consistency and readability. The changes include replacing hardcoded string values with the `LoggingTheme` enum where applicable and removing unnecessary imports.

### Updates to `loggingTheme` usage:

* [`examples-java/src/main/java/com/embabel/example/AgentMcpApplication.java`](diffhunk://#diff-3e6f079302c5f8dbc8911dfb3fc3b0b3fe024edda5728ae2464101a0885ebf20R21-R24): Removed the `loggingTheme` attribute from the `@EnableAgentMcp` annotation, implying the default theme will now be used.
* [`examples-java/src/main/java/com/embabel/example/AgentShellApplication.java`](diffhunk://#diff-632164c33f382a8ec33e3f556d1f58718712efc6b514feb87550dcad88adc424R21-R24): Updated the `loggingTheme` attribute in the `@EnableAgentShell` annotation to use the `LoggingTheme.STARWARS` enum value instead of a hardcoded string.
* [`examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt`](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0R21-R24): Similarly updated the `loggingTheme` attribute in the `@EnableAgentShell` annotation to use the `LoggingTheme.STARWARS` enum value instead of a hardcoded string.