### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ The new `loggingTheme` attribute on `@EnableAgentShell` allows you to customize 
 // Star Wars themed logging
 @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
 
-// Severance themed logging
-@EnableAgentShell(loggingTheme = "severance")
+// Severance themed logging is a default.
+@EnableAgentShell
 
-// Default logging theme is set to "severance"
+// Default logging theme is set to LoggingTheme.SEVERANCE
 @EnableAgentShell
 ```
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify the usage of the `loggingTheme` attribute in the `@EnableAgentShell` annotation. It also standardizes the way the default logging theme is referenced.

Documentation updates:

* Updated the `README.md` to indicate that Severance-themed logging is the default and no longer requires specifying the `loggingTheme` attribute explicitly.
* Standardized the reference to the default logging theme by using `LoggingTheme.SEVERANCE` instead of a string literal `"severance"`.