### PR TITLE
Update LoggingTheme Enum Value.

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
@@ -21,7 +21,7 @@ import com.embabel.agent.config.annotation.EnableAgentShell;
 import com.embabel.agent.config.annotation.LoggingTheme;
 
 @SpringBootApplication
-@EnableAgentShell(loggingTheme=LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme=LoggingTheme.STAR_WARS)
 public class AgentShellApplication {    
     
   public static void main(String[] args) {

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
@@ -21,7 +21,7 @@ import com.embabel.agent.config.annotation.EnableAgentShell
 import com.embabel.agent.config.annotation.LoggingTheme
 
 @SpringBootApplication
-@EnableAgentShell(loggingTheme=LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme=LoggingTheme.STAR_WARS)
 class AgentShellApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request includes a minor update to correct a logging theme constant in the `@EnableAgentShell` annotation across both Java and Kotlin implementations of the `AgentShellApplication`.

Consistency and correctness updates:

* [`examples-java/src/main/java/com/embabel/example/AgentShellApplication.java`](diffhunk://#diff-632164c33f382a8ec33e3f556d1f58718712efc6b514feb87550dcad88adc424L24-R24): Updated the `loggingTheme` value from `LoggingTheme.STARWARS` to `LoggingTheme.STAR_WARS` for consistency with the defined constants.
* [`examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt`](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0L24-R24): Made the same update to the `loggingTheme` value in the Kotlin version of the `AgentShellApplication`.