### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The Embabel Agent framework now provides dedicated Spring Boot starter annotatio
 ```kotlin
 // For Interactive Shell Mode with Star Wars themed logging
 @SpringBootApplication
-@EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
 class AgentShellApplication
 
 fun main(args: Array<String>) {
@@ -98,7 +98,7 @@ fun main(args: Array<String>) {
 ```java
 // Java versions
 @SpringBootApplication
-@EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
 public class AgentShellApplication {
     public static void main(String[] args) {
         SpringApplication.run(AgentShellApplication.class, args);
@@ -122,7 +122,7 @@ public class AgentMcpApplication {
 - ✅ Human-in-the-loop capabilities
 - ✅ Progress tracking and logging
 - ✅ Development-friendly error handling
-- 🎨 **NEW**: Themed logging support (e.g., LoggingTheme.STARWARS, LoggingTheme.SEVERANCE)
+- 🎨 **NEW**: Themed logging support (e.g., LoggingTheme.STAR_WARS, LoggingTheme.SEVERANCE)
 
 #### **`@EnableAgentMcp`**
 - ✅ MCP protocol server implementation
@@ -137,7 +137,7 @@ The new `loggingTheme` attribute on `@EnableAgentShell` allows you to customize 
 
 ```kotlin
 // Star Wars themed logging
-@EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
 
 // Severance themed logging is a default.
 @EnableAgentShell
@@ -147,7 +147,7 @@ The new `loggingTheme` attribute on `@EnableAgentShell` allows you to customize 
 ```
 
 Available themes:
-- **`LoggingTheme.STARWARS`** - May the Force be with your logs! Adds Star Wars-themed logging messages
+- **`LoggingTheme.STAR_WARS`** - May the Force be with your logs! Adds Star Wars-themed logging messages
 - **`LoggingTheme.SEVERANCE`** - Welcome to Lumon Industries.
 
 ---
@@ -598,7 +598,7 @@ fun main(args: Array<String>) {
 ### **Shell Application with Themed Logging**
 ```kotlin
 @SpringBootApplication
-@EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+@EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
 class MyThemedAgentApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request updates the `README.md` file to correct the naming convention for the `LoggingTheme.STAR_WARS` constant, which was previously inconsistently referred to as `LoggingTheme.STARWARS`. This ensures consistency and clarity in the documentation.

### Documentation Updates:

* Updated all occurrences of `LoggingTheme.STARWARS` to `LoggingTheme.STAR_WARS` in Kotlin and Java code examples, ensuring consistency in the usage of the `loggingTheme` attribute in `@EnableAgentShell`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R140) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L601-R601)
* Corrected the description of the `LoggingTheme.STAR_WARS` option in the list of available themes to reflect the updated naming convention.
* Fixed the bullet point in the feature list to use `LoggingTheme.STAR_WARS` instead of the outdated `LoggingTheme.STARWARS`.