### PR TITLE
Keep default shell free of dependency on McpServers

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/AgentShellApplication.java
@@ -15,12 +15,12 @@
  */
 package com.embabel.example;
 
-import com.embabel.agent.config.annotation.LoggingThemes;
-import com.embabel.agent.config.annotation.McpServers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import com.embabel.agent.config.annotation.EnableAgentShell;
 import com.embabel.agent.config.annotation.EnableAgents;
+import com.embabel.agent.config.annotation.LoggingThemes;
+
 
 /**
  * Spring Boot application that provides an interactive command-line shell for Embabel agents
@@ -38,9 +38,7 @@ import com.embabel.agent.config.annotation.EnableAgents;
 @SpringBootApplication
 @EnableAgentShell
 @EnableAgents(
-    loggingTheme = LoggingThemes.SEVERANCE,
-        mcpServers = { com.embabel.agent.config.annotation.McpServers.DOCKER_DESKTOP,
-                       McpServers.DOCKER }
+    loggingTheme = LoggingThemes.SEVERANCE
 )
 public class AgentShellApplication {
     

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt
@@ -20,7 +20,6 @@ import org.springframework.boot.runApplication
 import com.embabel.agent.config.annotation.EnableAgentShell
 import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
-import com.embabel.agent.config.annotation.McpServers
 
 /**
  * Spring Boot application that runs Embabel agents in interactive shell mode.
@@ -43,7 +42,6 @@ import com.embabel.agent.config.annotation.McpServers
 @EnableAgentShell
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
-    mcpServers = [McpServers.DOCKER_DESKTOP, McpServers.DOCKER],
 )
 class AgentShellApplication
 


### PR DESCRIPTION
This pull request removes the `mcpServers` configuration parameter from the `@EnableAgents` annotation in both the Java and Kotlin examples of the `AgentShellApplication`. Additionally, it cleans up unused imports related to `McpServers`.

### There is a dedicated shell_mcp_client,sh and shell_mcp_client.cmd to run samples with Docker Tools Support

### Removal of `mcpServers` configuration:
* [`examples-java/src/main/java/com/embabel/example/AgentShellApplication.java`](diffhunk://#diff-632164c33f382a8ec33e3f556d1f58718712efc6b514feb87550dcad88adc424L18-R23): Removed the `mcpServers` parameter from the `@EnableAgents` annotation and its associated imports. [[1]](diffhunk://#diff-632164c33f382a8ec33e3f556d1f58718712efc6b514feb87550dcad88adc424L18-R23) [[2]](diffhunk://#diff-632164c33f382a8ec33e3f556d1f58718712efc6b514feb87550dcad88adc424L41-R41)
* [`examples-kotlin/src/main/kotlin/com/embabel/example/AgentShellApplication.kt`](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0L23): Removed the `mcpServers` parameter from the `@EnableAgents` annotation and its associated imports. [[1]](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0L23) [[2]](diffhunk://#diff-b0578edf8eec7aef33d6b509b05d416af4b65e9ebdf1d5dda0c70708f81c30b0L46)