### PR TITLE
Update application path from Java to Kotlin

### DIFF
--- a/scripts/kotlin/shell.sh
+++ b/scripts/kotlin/shell.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export AGENT_APPLICATION=../../examples-java
+export AGENT_APPLICATION=../../examples-kotlin
 
 ../support/shell_template.sh "$@"


### PR DESCRIPTION
Change `AGENT_APPLICATION` path from examples-java to examples-kotlin to support the project's migration from Java to Kotlin.