### PR TITLE
Fix to redirect to Kotlin Examples.

### DIFF
--- a/scripts/kotlin/shell.sh
+++ b/scripts/kotlin/shell.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export AGENT_APPLICATION=../../examples-java
+export AGENT_APPLICATION=../../examples-kotlin
 
 ../support/shell_template.sh "$@"


### PR DESCRIPTION
This pull request includes a small change to the `scripts/kotlin/shell.sh` file. The change updates the `AGENT_APPLICATION` environment variable to point to the `examples-kotlin` directory instead of `examples-java`.