### PR TITLE
Clean stale class files before launching examples.

### DIFF
--- a/scripts/support/agent.bat
+++ b/scripts/support/agent.bat
@@ -29,6 +29,6 @@ REM Display what we're running
 echo Starting application with profile: %MAVEN_PROFILE%
 echo Application path: %AGENT_APPLICATION%
 
-cmd /c ..\..\mvnw -U -P %MAVEN_PROFILE% -f %POM_FILE% -Dmaven.test.skip=true spring-boot:run
+cmd /c ..\..\mvnw -U -P %MAVEN_PROFILE% -f %POM_FILE% -Dmaven.test.skip=true clean spring-boot:run
 
 endlocal

--- a/scripts/support/agent.sh
+++ b/scripts/support/agent.sh
@@ -43,4 +43,4 @@ echo "Starting application with profile: $MAVEN_PROFILE"
 echo "Application path: $AGENT_APPLICATION"
 
 # Run Maven Spring Boot application
-../../mvnw -U -P "$MAVEN_PROFILE" -f "$POM_FILE" -Dmaven.test.skip=true spring-boot:run
+../../mvnw -U -P "$MAVEN_PROFILE" -f "$POM_FILE" -Dmaven.test.skip=true clean spring-boot:run


### PR DESCRIPTION
This pull request updates the Maven commands in the agent scripts to include the `clean` phase before running the Spring Boot application. This ensures that any previous build artifacts are removed, providing a clean slate for the application run.

Updates to Maven commands:

* [`scripts/support/agent.bat`](diffhunk://#diff-2d29aef83c66546d9d1ad2a40f654db76a80b25f7a0bdd8e21c97ac3311161e8L32-R32): Added the `clean` phase to the Maven command in the batch script to ensure a clean build before running the application.
* [`scripts/support/agent.sh`](diffhunk://#diff-9af3ac2f65026416535910c43d3a6d1494392c8b4a4742b409ef85fd7ccf3ad5L46-R46): Added the `clean` phase to the Maven command in the shell script to ensure a clean build before running the application.