### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,16 @@
 
     <repositories>
         <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>


### PR DESCRIPTION
This pull request adds a new Maven repository to the `pom.xml` file. The new repository, `embabel-releases`, is configured to provide access to released artifacts from Embabel, with snapshots disabled.

Repository configuration:

* Added the `embabel-releases` Maven repository to the `<repositories>` section in `pom.xml`, enabling access to released artifacts from `https://repo.embabel.com/artifactory/libs-release` and disabling snapshots.