### PR TITLE
Update kotlin horoscope example to use injected context instead of de…

### DIFF
--- a/scripts/kotlin/shell.sh
+++ b/scripts/kotlin/shell.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-export AGENT_APPLICATION=../../examples-kotlin
+# Resolve the directory this script is in
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-../support/shell_template.sh "$@"
+# Set the path relative to this script's directory
+export AGENT_APPLICATION="$SCRIPT_DIR/../../examples-kotlin"
+
+# Call the shell_template.sh relative to this script's location
+"$SCRIPT_DIR/../support/shell_template.sh" "$@"

--- a/scripts/support/agent.sh
+++ b/scripts/support/agent.sh
@@ -43,4 +43,4 @@ echo "Starting application with profile: $MAVEN_PROFILE"
 echo "Application path: $AGENT_APPLICATION"
 
 # Run Maven Spring Boot application
-../../mvnw -U -P "$MAVEN_PROFILE" -f "$POM_FILE" -Dmaven.test.skip=true clean spring-boot:run
+$SCRIPT_DIR/../../mvnw -U -P "$MAVEN_PROFILE" -f "$POM_FILE" -Dmaven.test.skip=true clean spring-boot:run


### PR DESCRIPTION
Update kotlin horoscope example to use injected context instead of deprecated method

Fix scripts/kotlin/shell.sh so that it can be called from root dir without error. 