### PR TITLE
Update embabel-agent to 0.1.1-SNAPSHOT

### DIFF
--- a/examples-common/pom.xml
+++ b/examples-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>examples-common</artifactId>
     <name>Embabel Example Agent Common</name>

--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example.java</groupId>
     <artifactId>example-agent-java</artifactId>

--- a/examples-java/src/main/java/com/embabel/example/repeatuntil/GoatWriterConfig.java
+++ b/examples-java/src/main/java/com/embabel/example/repeatuntil/GoatWriterConfig.java
@@ -15,7 +15,7 @@
  */
 package com.embabel.example.repeatuntil;
 
-import com.embabel.agent.api.common.workflow.RepeatUntilBuilder;
+import com.embabel.agent.api.common.workflow.RepeatUntilAcceptableBuilder;
 import com.embabel.agent.api.common.workflow.TextFeedback;
 import com.embabel.agent.core.Agent;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +32,7 @@ public class GoatWriterConfig {
 
     @Bean
     public Agent goatWriter() {
-        return RepeatUntilBuilder
+        return RepeatUntilAcceptableBuilder
                 .returning(Goat.class)
                 .withMaxIterations(3)
                 .repeating(context -> {

--- a/examples-java/src/main/java/com/embabel/example/repeatuntil/ReviseStoryUntilSatisfied.java
+++ b/examples-java/src/main/java/com/embabel/example/repeatuntil/ReviseStoryUntilSatisfied.java
@@ -19,7 +19,7 @@ import com.embabel.agent.api.annotation.AchievesGoal;
 import com.embabel.agent.api.annotation.Action;
 import com.embabel.agent.api.annotation.Agent;
 import com.embabel.agent.api.common.ActionContext;
-import com.embabel.agent.api.common.workflow.RepeatUntilBuilder;
+import com.embabel.agent.api.common.workflow.RepeatUntilAcceptableBuilder;
 import com.embabel.agent.api.common.workflow.TextFeedback;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.common.ai.model.LlmOptions;
@@ -42,7 +42,7 @@ class ReviseStoryUntilSatisfied {
                 .withLlm(LlmOptions.fromModel("gpt-4.1-mini").withTemperature(.8));
         var reviewerPromptRunner = actionContext.promptRunner()
                 .withLlm(LlmOptions.fromModel("gpt-4.1-mini"));
-        return RepeatUntilBuilder
+        return RepeatUntilAcceptableBuilder
                 .returning(Story.class)
                 .withMaxIterations(7)
                 .withScoreThreshold(.8)

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>example-agent-kotlin</artifactId>
     <name>Embabel Agent Kotlin Examples</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.agent</groupId>
         <artifactId>embabel-agent-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example</groupId>
     <artifactId>example-agent-parent</artifactId>


### PR DESCRIPTION
This pull request updates the project to use version `0.1.1-SNAPSHOT` across all modules and replaces usage of `RepeatUntilBuilder` with `RepeatUntilAcceptableBuilder` in the Java example code. These changes ensure consistency in dependency versions and align the code with the latest API updates.

Dependency and version updates:
* Updated the parent POM version from `0.1.0-SNAPSHOT` to `0.1.1-SNAPSHOT` in `pom.xml`, `examples-common/pom.xml`, `examples-java/pom.xml`, and `examples-kotlin/pom.xml` to keep all modules consistent with the latest snapshot version. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8) [[2]](diffhunk://#diff-6d3995563adebce51c2d5e2f93e1374105df789fd70acd7faf688f3b7cd71141L8-R8) [[3]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201L8-R8) [[4]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L8-R8)

API usage updates:
* Replaced all imports and usages of `RepeatUntilBuilder` with `RepeatUntilAcceptableBuilder` in `GoatWriterConfig.java` and `ReviseStoryUntilSatisfied.java` to use the updated workflow API. [[1]](diffhunk://#diff-8dcad7d9f0d4f7776daaebded2538ccc41308013caa6e798846ede86b20e819eL18-R18) [[2]](diffhunk://#diff-8dcad7d9f0d4f7776daaebded2538ccc41308013caa6e798846ede86b20e819eL35-R35) [[3]](diffhunk://#diff-7f44293b1471e34edddef141f0a1457ec40543c87c54548a1865a06afd299f28L22-R22) [[4]](diffhunk://#diff-7f44293b1471e34edddef141f0a1457ec40543c87c54548a1865a06afd299f28L45-R45)