### PR TITLE
Fix failure on startup with --docker-tools

### DIFF
--- a/scripts/support/shell_template.bat
+++ b/scripts/support/shell_template.bat
@@ -30,6 +30,6 @@ if "%MAVEN_PROFILE%"=="enable-shell" (
     echo.
 )
 
-call "%~dp0agent.bat"
+call %~dp0..\support\agent.bat
 
 endlocal


### PR DESCRIPTION
This pull request updates the way the `agent.bat` script is invoked in the `scripts/support/shell_template.bat` file to use a relative path, improving compatibility and reliability.

Path update:

* Changed the call to `agent.bat` to use a relative path (`%~dp0..\support\agent.bat`) instead of the previous method (`"%~dp0agent.bat"`), ensuring the script is correctly located and executed.This was broken on Windows only.