### PR TITLE
Add Embabel Starters for OpenAi and Anthropic models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,18 @@
         <module>examples-common</module>
     </modules>
 
+   <dependencies>
+       <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-openai</artifactId>
+       </dependency>
+
+       <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-anthropic</artifactId>
+       </dependency>
+   </dependencies>
+
     <repositories>
         <repository>
             <id>embabel-releases</id>


### PR DESCRIPTION
This pull request adds new dependencies to the project's `pom.xml` to support integration with both OpenAI and Anthropic agent starters. These changes enable the project to utilize functionalities provided by the `embabel-agent-starter-openai` and `embabel-agent-starter-anthropic` modules.

Dependency additions:

* Added `embabel-agent-starter-openai` as a dependency to enable OpenAI agent integration.
* Added `embabel-agent-starter-anthropic` as a dependency to enable Anthropic agent integration.