### PR TITLE
Move openai and anthropic starters to java and kotlin POMs for clarity.

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -25,6 +25,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-anthropic</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.shell</groupId>
             <artifactId>spring-shell-standard</artifactId>
             <version>${spring-shell-standard.version}</version>

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -22,6 +22,16 @@
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-anthropic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,18 +19,6 @@
         <module>examples-common</module>
     </modules>
 
-   <dependencies>
-       <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-openai</artifactId>
-       </dependency>
-
-       <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-anthropic</artifactId>
-       </dependency>
-   </dependencies>
-
     <repositories>
         <repository>
             <id>embabel-releases</id>


### PR DESCRIPTION
This pull request reorganizes how the `embabel-agent-starter-openai` and `embabel-agent-starter-anthropic` dependencies are managed in the project. These dependencies have been removed from the top-level `pom.xml` and added specifically to the `examples-java` and `examples-kotlin` modules. This change improves dependency management by limiting the scope of these dependencies to only the modules that require them.

Dependency management improvements:

* Removed `embabel-agent-starter-openai` and `embabel-agent-starter-anthropic` dependencies from the root `pom.xml`, so they are no longer available to all modules by default.
* Added `embabel-agent-starter-openai` and `embabel-agent-starter-anthropic` dependencies to `examples-java/pom.xml`, ensuring they are only included where needed.
* Added `embabel-agent-starter-openai` and `embabel-agent-starter-anthropic` dependencies to `examples-kotlin/pom.xml`, ensuring they are only included where needed.