### PR TITLE
Local model

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -24,14 +24,10 @@
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Ollama is always included as an option for local model hosting -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-openai</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-anthropic</artifactId>
+            <artifactId>embabel-agent-starter-ollama</artifactId>
         </dependency>
 
         <dependency>
@@ -60,6 +56,34 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>openai-models</id>
+            <activation>
+                <property>
+                    <name>env.OPENAI_API_KEY</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-openai</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>anthropic-models</id>
+            <activation>
+                <property>
+                    <name>env.ANTHROPIC_API_KEY</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-anthropic</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>enable-shell</id>
             <activation>

--- a/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
@@ -20,7 +20,7 @@ import com.embabel.agent.config.annotation.LoggingThemes;
 import com.embabel.agent.config.annotation.McpServers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 
 /**
@@ -36,7 +36,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * @since 1.0
  */
 @SpringBootApplication
-@EnableConfigurationProperties
+@ConfigurationPropertiesScan(
+        basePackages = {
+                "com.embabel.example"
+        }
+)
 @EnableAgents(
         loggingTheme = LoggingThemes.SEVERANCE,
         mcpServers = {McpServers.DOCKER_DESKTOP}

--- a/examples-java/src/main/java/com/embabel/example/JavaAgentShellMcpClientApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaAgentShellMcpClientApplication.java
@@ -20,7 +20,7 @@ import com.embabel.agent.config.annotation.LoggingThemes;
 import com.embabel.agent.config.annotation.McpServers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Spring Boot application that provides an interactive command-line shell for Embabel agents
@@ -35,7 +35,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
  * @since 1.0
  */
 @SpringBootApplication
-@EnableConfigurationProperties
+@ConfigurationPropertiesScan(
+        basePackages = {
+                "com.embabel.example"
+        }
+)
 @EnableAgents(
         loggingTheme = LoggingThemes.STAR_WARS,
         mcpServers = {McpServers.DOCKER_DESKTOP}

--- a/examples-java/src/main/java/com/embabel/example/JavaMcpServerApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaMcpServerApplication.java
@@ -19,6 +19,7 @@ import com.embabel.agent.config.annotation.EnableAgents;
 import com.embabel.agent.config.annotation.McpServers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Spring Boot application that runs Embabel agents as an MCP (Model Context Protocol) server.
@@ -32,6 +33,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @since 1.0
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan(
+        basePackages = {
+                "com.embabel.example"
+        }
+)
 @EnableAgents(
         mcpServers = {McpServers.DOCKER_DESKTOP}
 )

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -13,21 +13,16 @@
 
     <dependencies>
 
-
         <dependency>
             <groupId>com.embabel.example</groupId>
             <artifactId>examples-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
+        <!-- Ollama is always included as an option for local model hosting -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-openai</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-anthropic</artifactId>
+            <artifactId>embabel-agent-starter-ollama</artifactId>
         </dependency>
 
         <dependency>
@@ -61,6 +56,34 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>openai-models</id>
+            <activation>
+                <property>
+                    <name>env.OPENAI_API_KEY</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-openai</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>anthropic-models</id>
+            <activation>
+                <property>
+                    <name>env.ANTHROPIC_API_KEY</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-anthropic</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>enable-shell</id>
             <activation>

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentMcpServerApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentMcpServerApplication.kt
@@ -18,6 +18,7 @@ package com.embabel.example
 import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
@@ -29,10 +30,13 @@ import org.springframework.boot.runApplication
  *
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan(
+    basePackages = ["com.embabel.example"]
+)
 @EnableAgents(
     mcpServers = [McpServers.DOCKER_DESKTOP, McpServers.DOCKER],
 )
-class JavaAgentMcpServerApplication
+class KotlinAgentMcpServerApplication
 
 /**
  * Application entry point that starts the MCP server.
@@ -43,5 +47,5 @@ class JavaAgentMcpServerApplication
  * @param args Command line arguments passed to the application
  */
 fun main(args: Array<String>) {
-    runApplication<JavaAgentMcpServerApplication>(*args)
+    runApplication<KotlinAgentMcpServerApplication>(*args)
 }

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
 import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
@@ -38,6 +39,9 @@ import org.springframework.boot.runApplication
  * @see EnableAgents
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan(
+    basePackages = ["com.embabel.example"]
+)
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
     mcpServers = [McpServers.DOCKER, McpServers.DOCKER_DESKTOP],

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellMcpClientApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellMcpClientApplication.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
 import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 /**
@@ -38,6 +39,9 @@ import org.springframework.boot.runApplication
  * @see EnableAgents
  */
 @SpringBootApplication
+@ConfigurationPropertiesScan(
+    basePackages = ["com.embabel.example"]
+)
 @EnableAgents(
     loggingTheme = LoggingThemes.SEVERANCE,
     mcpServers = [McpServers.DOCKER_DESKTOP, McpServers.DOCKER],

--- a/scripts/support/check_env.bat
+++ b/scripts/support/check_env.bat
@@ -7,8 +7,6 @@ set ANTHROPIC_KEY_MISSING=false
 if "%OPENAI_API_KEY%"=="" (
     echo OPENAI_API_KEY environment variable is not set
     echo OpenAI models will not be available
-    echo Get an API key at https://platform.openai.com/api-keys
-    echo Please set it with: set OPENAI_API_KEY=your_api_key
     set OPENAI_KEY_MISSING=true
 ) else (
     echo OPENAI_API_KEY set: OpenAI models are available
@@ -17,16 +15,13 @@ if "%OPENAI_API_KEY%"=="" (
 if "%ANTHROPIC_API_KEY%"=="" (
     echo ANTHROPIC_API_KEY environment variable is not set
     echo Claude models will not be available
-    echo Get an API key at https://www.anthropic.com/api
-    echo Please set it with: set ANTHROPIC_API_KEY=your_api_key
     set ANTHROPIC_KEY_MISSING=true
 ) else (
     echo ANTHROPIC_API_KEY set: Claude models are available
 )
 
 if "%OPENAI_KEY_MISSING%"=="true" if "%ANTHROPIC_KEY_MISSING%"=="true" (
-    echo ERROR: Both OPENAI_API_KEY and ANTHROPIC_API_KEY are missing.
-    echo At least one API key is required to use language models.
-    echo Please set at least one of these keys before running the application.
-    exit /b 1
+    echo Ollama models will be used if available
+    echo Please check Ollama installation and set default model in application.properties
+    echo For example: embabel.models.default-llm=llama3.1:8b
 )


### PR DESCRIPTION
This pull request improves how model dependencies are managed and configures property scanning for Spring Boot applications in both the Java and Kotlin example projects. It makes Ollama the default always-included model backend, while OpenAI and Anthropic dependencies are now activated only if the corresponding API keys are set. Additionally, it updates the Spring Boot configuration to use `@ConfigurationPropertiesScan` for property binding. The environment check script is also updated to better handle missing API keys.

**Dependency management improvements:**

* Ollama is now always included as a dependency for local model hosting in both `examples-java/pom.xml` and `examples-kotlin/pom.xml`. OpenAI and Anthropic dependencies are removed from the default dependencies and instead added under Maven profiles that activate only if the respective API keys are present in the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). [[1]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201R27-R30) [[2]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201R59-R86) [[3]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L16-R25) [[4]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8R59-R86)

**Spring Boot configuration enhancements:**

* Replaces `@EnableConfigurationProperties` with `@ConfigurationPropertiesScan` (scanning the `com.embabel.example` package) in all Java and Kotlin example applications to improve property binding and configuration. [[1]](diffhunk://#diff-e7c6448f16160e953786449c4e8a1733db839dde5d6e6b9bf6f48afbba9d77c7L23-R23) [[2]](diffhunk://#diff-e7c6448f16160e953786449c4e8a1733db839dde5d6e6b9bf6f48afbba9d77c7L39-R43) [[3]](diffhunk://#diff-2bcbb68e2d7638ee7bbd43082b91d15c9322652ee035ea98d47ffa7aa16fd503L23-R23) [[4]](diffhunk://#diff-2bcbb68e2d7638ee7bbd43082b91d15c9322652ee035ea98d47ffa7aa16fd503L38-R42) [[5]](diffhunk://#diff-b102bc6a503268066302bf80aefcf2ad7e58a57ae023d1d1923a476552244444R22) [[6]](diffhunk://#diff-b102bc6a503268066302bf80aefcf2ad7e58a57ae023d1d1923a476552244444R36-R40) [[7]](diffhunk://#diff-106619e9f808f8d7bcd4accbf7de476fa72cdda30e856b22c05002c31cfebdcaR21) [[8]](diffhunk://#diff-106619e9f808f8d7bcd4accbf7de476fa72cdda30e856b22c05002c31cfebdcaR33-R39) [[9]](diffhunk://#diff-501b7f811b9028c485831c2bc09baefaf068060a4a216630f86d0d0e0fcd3579R22) [[10]](diffhunk://#diff-501b7f811b9028c485831c2bc09baefaf068060a4a216630f86d0d0e0fcd3579R42-R44) [[11]](diffhunk://#diff-cba28e7afcbd89c0ccb82b2faa4dc8504cf434f4e629fb9a9e7b470364058142R22) [[12]](diffhunk://#diff-cba28e7afcbd89c0ccb82b2faa4dc8504cf434f4e629fb9a9e7b470364058142R42-R44)

**Other improvements:**

* Updates the environment check batch script (`scripts/support/check_env.bat`) to remove API key instructions and clarify that Ollama will be used if both API keys are missing, with a reminder to check Ollama installation and set the default model. [[1]](diffhunk://#diff-e928624b95cf01c82194f30935c31f1aed2996565120d8b17c6218fcf36028ceL10-L11) [[2]](diffhunk://#diff-e928624b95cf01c82194f30935c31f1aed2996565120d8b17c6218fcf36028ceL20-R26)
* Fixes a class naming issue in the Kotlin MCP server application, renaming `JavaAgentMcpServerApplication` to `KotlinAgentMcpServerApplication`. [[1]](diffhunk://#diff-106619e9f808f8d7bcd4accbf7de476fa72cdda30e856b22c05002c31cfebdcaR33-R39) [[2]](diffhunk://#diff-106619e9f808f8d7bcd4accbf7de476fa72cdda30e856b22c05002c31cfebdcaL46-R50)