### PR TITLE
Add support for docker models

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -85,6 +85,20 @@
             </dependencies>
         </profile>
         <profile>
+            <id>docker-models</id>
+            <activation>
+                <property>
+                    <name>env.DOCKER_MODELS_AVAILABLE</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-dockermodels</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>enable-shell</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -85,6 +85,20 @@
             </dependencies>
         </profile>
         <profile>
+            <id>docker-models</id>
+            <activation>
+                <property>
+                    <name>env.DOCKER_MODELS_AVAILABLE</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-dockermodels</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>enable-shell</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
This pull request adds a new Maven profile to both the Java and Kotlin example projects, enabling support for Docker-based models when a specific environment variable is set. This makes it easier to conditionally include Docker model dependencies during builds.

Dependency management improvements:

* Added a `docker-models` Maven profile to `examples-java/pom.xml` that activates when the `DOCKER_MODELS_AVAILABLE` environment variable is set, including the `embabel-agent-starter-dockermodels` dependency.
* Added a similar `docker-models` Maven profile to `examples-kotlin/pom.xml` with the same activation condition and dependency.