### PR TITLE
Sync up with 0.1.4-SNAPSHOT

### DIFF
--- a/examples-common/pom.xml
+++ b/examples-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>0.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>examples-common</artifactId>
     <name>Embabel Example Agent Common</name>

--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>0.1.4-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example.java</groupId>
     <artifactId>example-agent-java</artifactId>

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>0.1.4-SNAPSHOT</version>
     </parent>
     <artifactId>example-agent-kotlin</artifactId>
     <name>Embabel Agent Kotlin Examples</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.agent</groupId>
         <artifactId>embabel-agent-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>0.1.4-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example</groupId>
     <artifactId>example-agent-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent project version across multiple Maven `pom.xml` files to `0.1.4-SNAPSHOT`. This ensures all modules are aligned with the latest snapshot version.

Version updates:

* Updated the parent version from `0.1.3-SNAPSHOT` to `0.1.4-SNAPSHOT` in `examples-common/pom.xml`
* Updated the parent version from `0.1.3-SNAPSHOT` to `0.1.4-SNAPSHOT` in `examples-java/pom.xml`
* Updated the parent version from `0.1.3-SNAPSHOT` to `0.1.4-SNAPSHOT` in `examples-kotlin/pom.xml`
* Updated the parent version from `0.1.3-SNAPSHOT` to `0.1.4-SNAPSHOT` in the root `pom.xml`