### PR TITLE
Add Bedrock Model Support

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -17,7 +17,6 @@
 
 
     <dependencies>
-
         <dependency>
             <groupId>com.embabel.example</groupId>
             <artifactId>examples-common</artifactId>
@@ -84,11 +83,25 @@
                 </dependency>
             </dependencies>
         </profile>
+         <profile>
+            <id>bedrock-models</id>
+            <activation>
+                <property>
+                    <name>env.ENABLE_BEDROCK</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.embabel.agent</groupId>
+                    <artifactId>embabel-agent-starter-bedrock</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
         <profile>
             <id>docker-models</id>
             <activation>
                 <property>
-                    <name>env.DOCKER_MODELS_AVAILABLE</name>
+                    <name>env.ENABLE_DOCKER_MODELS</name>
                 </property>
             </activation>
             <dependencies>


### PR DESCRIPTION
This pull request updates the Maven configuration in `examples-java/pom.xml` to improve support for model selection via environment variables. The most significant changes are the addition of a new profile for Bedrock models and the renaming of an environment variable for Docker models.

Model profile enhancements:

* Added a new Maven profile `bedrock-models` that activates when `env.ENABLE_BEDROCK` is set, including the `embabel-agent-starter-bedrock` dependency.
* Renamed the activation property for the `docker-models` profile from `env.DOCKER_MODELS_AVAILABLE` to `env.ENABLE_DOCKER_MODELS` for consistency and clarity.

General dependency section cleanup:

* Minor formatting adjustment in the dependencies section to remove an unnecessary blank line.