### PR TITLE
Sanitize file name. Breaks on Windows

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/crew/bookwriter/BookWriter.java
+++ b/examples-java/src/main/java/com/embabel/example/crew/bookwriter/BookWriter.java
@@ -92,7 +92,10 @@ record BookWriterConfig(
 
     public Path saveContent(Book book) {
         var dir = outputDirectory != null ? outputDirectory : System.getProperty("user.dir");
-        var fileName = book.title().replace(" ", "_").toLowerCase() + ".md";
+        var fileName = book.title()
+                .replaceAll("[<>:\"|*?/\\\\]", "_")
+                .replace(" ", "_")
+                .toLowerCase() + ".md";
         return FileTools.readWrite(dir).createFile("books" + File.separator + fileName, book.text(), true);
     }
 }


### PR DESCRIPTION
This pull request improves the file naming logic when saving book content, making it more robust against invalid characters that could cause issues on various file systems.

File name sanitization:

* Updated the file name generation in the `saveContent` method of `BookWriterConfig` (in `BookWriter.java`) to replace potentially problematic characters (`[<>:"|*?/\]`) with underscores, in addition to replacing spaces and converting to lowercase. This helps prevent errors when creating files with book titles that contain special characters.