### PR TITLE
Shell with Docker Tools as default

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
@@ -42,8 +42,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
         }
 )
 @EnableAgents(
-        loggingTheme = LoggingThemes.SEVERANCE,
-        mcpServers = {McpServers.DOCKER_DESKTOP}
+        loggingTheme = LoggingThemes.SEVERANCE
 )
 public class JavaAgentShellApplication {
 

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
@@ -17,7 +17,6 @@ package com.embabel.example
 
 import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
-import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
@@ -44,7 +43,6 @@ import org.springframework.boot.runApplication
 )
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
-    mcpServers = [McpServers.DOCKER, McpServers.DOCKER_DESKTOP],
 )
 class KotlinAgentShellApplication
 

--- a/scripts/support/shell_template.bat
+++ b/scripts/support/shell_template.bat
@@ -1,19 +1,19 @@
 @echo off
 setlocal
-
 REM This script requires AGENT_APPLICATION to be set by the calling script
 if not defined AGENT_APPLICATION (
     echo ERROR: AGENT_APPLICATION must be set by calling script
     exit /b 1
 )
 
-set MAVEN_PROFILE=enable-shell
+REM Default: Docker tools enabled (reversed from original logic)
+set MAVEN_PROFILE=enable-shell-mcp-client
 
-REM Check for --docker-tools parameter
+REM Check for --no-docker-tools parameter to disable tools
 :parse_args
 if "%~1"=="" goto end_parse
-if "%~1"=="--docker-tools" (
-    set MAVEN_PROFILE=enable-shell-mcp-client
+if "%~1"=="--no-docker-tools" (
+    set MAVEN_PROFILE=enable-shell
     shift
     goto parse_args
 )
@@ -23,13 +23,19 @@ goto parse_args
 
 :end_parse
 
-REM Display feature availability warning
+REM Display startup message about Docker tools status
+if "%MAVEN_PROFILE%"=="enable-shell-mcp-client" (
+    powershell -Command "Write-Host 'INFO: Docker tools are enabled (default behavior)' -ForegroundColor Green"
+    powershell -Command "Write-Host 'Use --no-docker-tools to disable Docker integration if needed' -ForegroundColor Cyan"
+    echo.
+)
+
+REM Display feature availability warning when tools are disabled
 if "%MAVEN_PROFILE%"=="enable-shell" (
     powershell -Command "Write-Host 'WARNING: Only Basic Agent features will be available' -ForegroundColor Red"
-    powershell -Command "Write-Host 'Use --docker-tools parameter to enable advanced Docker integration features' -ForegroundColor Yellow"
+    powershell -Command "Write-Host 'Docker tools have been disabled. Remove --no-docker-tools to enable advanced features' -ForegroundColor Yellow"
     echo.
 )
 
 call %~dp0..\support\agent.bat
-
 endlocal

--- a/scripts/support/shell_template.sh
+++ b/scripts/support/shell_template.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-
 # This script requires AGENT_APPLICATION to be set by the calling script
 if [ -z "$AGENT_APPLICATION" ]; then
     echo "ERROR: AGENT_APPLICATION must be set by calling script"
     exit 1
 fi
 
-export MAVEN_PROFILE=enable-shell
+# Default: Docker tools enabled (reversed from original logic)
+export MAVEN_PROFILE=enable-shell-mcp-client
 
-# Check for --docker-tools parameter
+# Check for --no-docker-tools parameter to disable tools
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --docker-tools)
-            export MAVEN_PROFILE=enable-shell-mcp-client
+        --no-docker-tools)
+            export MAVEN_PROFILE=enable-shell
             shift
             ;;
         *)
@@ -22,10 +22,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Display feature availability warning
+# Display startup message about Docker tools status
+if [ "$MAVEN_PROFILE" = "enable-shell-mcp-client" ]; then
+    echo -e "\033[32mINFO: Docker tools are enabled (default behavior)\033[0m"
+    echo -e "\033[36mUse --no-docker-tools to disable Docker integration if needed\033[0m"
+    echo
+fi
+
+# Display feature availability warning when tools are disabled
 if [ "$MAVEN_PROFILE" = "enable-shell" ]; then
     echo -e "\033[31mWARNING: Only Basic Agent features will be available\033[0m"
-    echo -e "\033[33mUse --docker-tools parameter to enable advanced Docker integration features\033[0m"
+    echo -e "\033[33mDocker tools have been disabled. Remove --no-docker-tools to enable advanced features\033[0m"
     echo
 fi
 


### PR DESCRIPTION
This pull request updates the agent shell startup scripts and refines agent configuration in both Java and Kotlin application examples. The main change is reversing the default behavior so Docker tools are enabled by default, with an option to disable them using a new parameter. The scripts and application annotations are updated for clarity and consistency.

**Shell script logic and messaging updates:**

* Changed default behavior in both `shell_template.bat` and `shell_template.sh` so Docker tools are enabled by default (`MAVEN_PROFILE=enable-shell-mcp-client`). The new `--no-docker-tools` parameter disables Docker integration, replacing the previous `--docker-tools` logic. Startup messages now clearly indicate the status and how to toggle Docker integration. [[1]](diffhunk://#diff-0aa8ae26fc59810132729e6531ac5200f434e416381e24f5fb86c5d91e3cda29L3-R16) [[2]](diffhunk://#diff-0aa8ae26fc59810132729e6531ac5200f434e416381e24f5fb86c5d91e3cda29L26-L34) [[3]](diffhunk://#diff-eaabb1168d159d7c4f0c7d426a61ae09d0f8b9a6fa0205ea37fa1399afc29105L2-R15) [[4]](diffhunk://#diff-eaabb1168d159d7c4f0c7d426a61ae09d0f8b9a6fa0205ea37fa1399afc29105L25-R35)

**Java and Kotlin application annotation cleanup:**

* Removed explicit Docker server configuration from `@EnableAgents` annotations in `JavaAgentShellApplication.java` and `KotlinAgentShellApplication.kt`, relying on the new default behavior for Docker tools. [[1]](diffhunk://#diff-e7c6448f16160e953786449c4e8a1733db839dde5d6e6b9bf6f48afbba9d77c7L45-R45) [[2]](diffhunk://#diff-501b7f811b9028c485831c2bc09baefaf068060a4a216630f86d0d0e0fcd3579L47)
* Removed unnecessary import of `McpServers` in the Kotlin example for cleaner code.