### PR TITLE
Fix broken tests

### DIFF
--- a/examples-java/src/test/java/com/embabel/example/horoscope/StarNewsFinderTest.java
+++ b/examples-java/src/test/java/com/embabel/example/horoscope/StarNewsFinderTest.java
@@ -55,9 +55,9 @@ public class StarNewsFinderTest {
             RelevantNewsStories relevantNewsStories = new RelevantNewsStories(Arrays.asList(cockatoos, emus));
             Horoscope horoscope = new Horoscope("This is a good day for you");
 
-            starNewsFinder.writeup(starPerson, relevantNewsStories, horoscope, context);
+            starNewsFinder.writeup(starPerson, relevantNewsStories, horoscope, context.ai());
 
-            var prompt = context.getLlmInvocations().getFirst().getPrompt();
+            var prompt = context.getLlmInvocations().getFirst().getMessages().getFirst().getContent();
             var toolGroups = context.getLlmInvocations().getFirst().getInteraction().getToolGroups();
 
 

--- a/examples-kotlin/src/test/kotlin/com/embabel/example/horoscope/StarNewsFinderTest.kt
+++ b/examples-kotlin/src/test/kotlin/com/embabel/example/horoscope/StarNewsFinderTest.kt
@@ -76,7 +76,7 @@ class StarNewsFinderTest {
                 context = context
             )
 
-            val prompt = context.llmInvocations.first().prompt
+            val prompt = context.llmInvocations.first().messages.first().content
             val toolGroups = context.llmInvocations.first().interaction.toolGroups
 
             assertTrue(prompt.contains(starPerson.name))


### PR DESCRIPTION
This pull request updates how prompts are accessed in the horoscope example tests for both Java and Kotlin. Instead of retrieving the prompt directly, the code now accesses the prompt content through the first message in the invocation. Additionally, the Java test now passes the AI context rather than the generic context to the `writeup` method.

Prompt handling improvements:
* Changed prompt retrieval in `StarNewsFinderTest.java` and `StarNewsFinderTest.kt` to fetch the prompt content from the first message rather than directly from the invocation. [[1]](diffhunk://#diff-0e1579fdab4987c893d8ae20eafdcab3c9875cd018eb996a6d20aeb49b7ee8f7L58-R60) [[2]](diffhunk://#diff-e42c76c1f6755c85b6254d0d7925ab57d3de9ab1e8261ddd4f2b33165b93f18dL79-R79)

Test invocation context:
* Updated the Java test to pass `context.ai()` instead of `context` to the `writeup` method, ensuring the correct context type is used for AI interactions.