### PR TITLE
Fixing imports due to OpenAiModels / AntrhopicModels package move

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/horoscope/StarNewsFinder.java
+++ b/examples-java/src/main/java/com/embabel/example/horoscope/StarNewsFinder.java
@@ -17,8 +17,8 @@ package com.embabel.example.horoscope;
 
 import com.embabel.agent.api.annotation.*;
 import com.embabel.agent.api.common.Ai;
-import com.embabel.agent.config.models.AnthropicModels;
-import com.embabel.agent.config.models.OpenAiModels;
+import com.embabel.agent.api.models.AnthropicModels;
+import com.embabel.agent.api.models.OpenAiModels;
 import com.embabel.agent.core.CoreToolGroups;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.agent.domain.library.Person;

--- a/examples-java/src/main/java/com/embabel/example/pydantic/banksupport/SupportAgent.java
+++ b/examples-java/src/main/java/com/embabel/example/pydantic/banksupport/SupportAgent.java
@@ -20,7 +20,7 @@ import com.embabel.agent.api.annotation.AchievesGoal;
 import com.embabel.agent.api.annotation.Action;
 import com.embabel.agent.api.annotation.Agent;
 import com.embabel.agent.api.common.OperationContext;
-import com.embabel.agent.config.models.OpenAiModels;
+import com.embabel.agent.api.models.OpenAiModels;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.data.repository.Repository;

--- a/examples-java/src/main/java/com/embabel/example/repeatuntil/GoatWriterConfig.java
+++ b/examples-java/src/main/java/com/embabel/example/repeatuntil/GoatWriterConfig.java
@@ -17,7 +17,8 @@ package com.embabel.example.repeatuntil;
 
 import com.embabel.agent.api.common.workflow.loop.RepeatUntilAcceptableBuilder;
 import com.embabel.agent.api.common.workflow.loop.TextFeedback;
-import com.embabel.agent.config.models.OpenAiModels;
+
+import com.embabel.agent.api.models.OpenAiModels;
 import com.embabel.agent.core.Agent;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/examples-java/src/main/java/com/embabel/example/repeatuntil/ReviseStoryUntilSatisfied.java
+++ b/examples-java/src/main/java/com/embabel/example/repeatuntil/ReviseStoryUntilSatisfied.java
@@ -21,7 +21,7 @@ import com.embabel.agent.api.annotation.Agent;
 import com.embabel.agent.api.common.ActionContext;
 import com.embabel.agent.api.common.workflow.loop.RepeatUntilAcceptableBuilder;
 import com.embabel.agent.api.common.workflow.loop.TextFeedback;
-import com.embabel.agent.config.models.OpenAiModels;
+import com.embabel.agent.api.models.OpenAiModels;
 import com.embabel.agent.domain.io.UserInput;
 import com.embabel.common.ai.model.LlmOptions;
 

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/factchecker/factChecker.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/factchecker/factChecker.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.common.createObject
 import com.embabel.agent.api.dsl.agent
 import com.embabel.agent.api.dsl.aggregate
 import com.embabel.agent.api.dsl.parallelMap
-import com.embabel.agent.config.models.AnthropicModels
+import com.embabel.agent.api.models.AnthropicModels
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.CoreToolGroups
 import com.embabel.agent.domain.io.UserInput

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/horoscope/StarNewsFinder.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/horoscope/StarNewsFinder.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.annotation.*
 import com.embabel.agent.api.common.OperationContext
 import com.embabel.agent.api.common.createObject
 import com.embabel.agent.api.common.createObjectIfPossible
-import com.embabel.agent.config.models.OpenAiModels
+import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.core.CoreToolGroups
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.HasContent

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/researcher/Researcher.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/researcher/Researcher.kt
@@ -18,8 +18,8 @@ package com.embabel.example.researcher
 import com.embabel.agent.api.annotation.*
 import com.embabel.agent.api.common.OperationContext
 import com.embabel.agent.api.common.create
-import com.embabel.agent.config.models.AnthropicModels
-import com.embabel.agent.config.models.OpenAiModels
+import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.core.CoreToolGroups
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.ResearchReport


### PR DESCRIPTION
 ## Overview

OpenAIModels   and AnthropicModels has been moved from "config" subpackage to "api" subpackage.

## Modified files

      modified:   examples-java/src/main/java/com/embabel/example/horoscope/StarNewsFinder.java
	modified:   examples-java/src/main/java/com/embabel/example/pydantic/banksupport/SupportAgent.java
	modified:   examples-java/src/main/java/com/embabel/example/repeatuntil/GoatWriterConfig.java
	modified:   examples-java/src/main/java/com/embabel/example/repeatuntil/ReviseStoryUntilSatisfied.java
	modified:   examples-kotlin/src/main/kotlin/com/embabel/example/factchecker/factChecker.kt
	modified:   examples-kotlin/src/main/kotlin/com/embabel/example/horoscope/StarNewsFinder.kt
	modified:   examples-kotlin/src/main/kotlin/com/embabel/example/researcher/Researcher.kt



