### PR TITLE
Update pom(s) to agent 0.2.0-SNAPSHOT

### DIFF
--- a/examples-common/pom.xml
+++ b/examples-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>examples-common</artifactId>
     <name>Embabel Example Agent Common</name>

--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example.java</groupId>
     <artifactId>example-agent-java</artifactId>

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.example</groupId>
         <artifactId>example-agent-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>example-agent-kotlin</artifactId>
     <name>Embabel Agent Kotlin Examples</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.agent</groupId>
         <artifactId>embabel-agent-parent</artifactId>
-        <version>0.1.4-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.example</groupId>
     <artifactId>example-agent-parent</artifactId>


### PR DESCRIPTION
This pull request updates the parent project version from `0.1.4-SNAPSHOT` to `0.2.0-SNAPSHOT` across multiple Maven `pom.xml` files. This change ensures that all modules are aligned with the latest parent version, which is important for consistency and access to new features or fixes introduced in the parent.

Version alignment:

* Updated the parent version to `0.2.0-SNAPSHOT` in `examples-common/pom.xml` to ensure the module uses the latest parent configuration.
* Updated the parent version to `0.2.0-SNAPSHOT` in `examples-java/pom.xml` for consistency with the parent project.
* Updated the parent version to `0.2.0-SNAPSHOT` in `examples-kotlin/pom.xml` to match the new parent version.
* Updated the parent version to `0.2.0-SNAPSHOT` in the root `pom.xml` for the main parent project.