### PR TITLE
Allow developers without Docker to bring up shell

### DIFF
--- a/examples-java/pom.xml
+++ b/examples-java/pom.xml
@@ -112,7 +112,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>enable-shell</id>
+            <id>enable-shell-mcp-client</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -136,7 +136,7 @@
             </build>
         </profile>
         <profile>
-            <id>enable-shell-mcp-client</id>
+            <id>enable-shell</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -152,7 +152,7 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <mainClass>com.embabel.example.JavaAgentShellMcpClientApplication</mainClass>
+                            <mainClass>com.embabel.example.JavaAgentSimpleShellApplication</mainClass>
                         </configuration>
                         <version>${spring-boot.version}</version>
                     </plugin>

--- a/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaAgentShellApplication.java
@@ -42,7 +42,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
         }
 )
 @EnableAgents(
-        loggingTheme = LoggingThemes.SEVERANCE,
+        loggingTheme = LoggingThemes.STAR_WARS,
         mcpServers = {McpServers.DOCKER_DESKTOP}
 )
 public class JavaAgentShellApplication {

--- a/examples-java/src/main/java/com/embabel/example/JavaAgentSimpleShellApplication.java
+++ b/examples-java/src/main/java/com/embabel/example/JavaAgentSimpleShellApplication.java
@@ -17,18 +17,22 @@ package com.embabel.example;
 
 import com.embabel.agent.config.annotation.EnableAgents;
 import com.embabel.agent.config.annotation.LoggingThemes;
-import com.embabel.agent.config.annotation.McpServers;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Spring Boot application that provides an interactive command-line shell for Embabel agents
- * with Star Wars themed logging and Docker Desktop integration.
+ * with Star Wars themed logging.
+ * <br>
+ * This is a simple example application demonstrating how to set up an Embabel agent
+ * environment with a customized logging theme.
+ * <br>
+ * Docker Tools are not enabled in this example to keep the setup straightforward,
+ * but keep in mind that some examples may require Docker Tools for full functionality.
  *
  * <p>This application runs in interactive shell mode, allowing developers to test and interact
- * with agents through a REPL-like interface. It combines the development-friendly shell
- * environment with fun Star Wars themed logging messages and Docker container capabilities.
+ * with agents through a REPL-like interface.
  *
  * @author Embabel Team
  * @see EnableAgents
@@ -41,20 +45,19 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
         }
 )
 @EnableAgents(
-        loggingTheme = LoggingThemes.STAR_WARS,
-        mcpServers = {McpServers.DOCKER_DESKTOP}
+        loggingTheme = LoggingThemes.SEVERANCE
 )
-public class JavaAgentShellMcpClientApplication {
+public class JavaAgentSimpleShellApplication {
 
     /**
      * Application entry point.
      *
      * <p>Starts the Spring Boot application with an interactive shell interface,
-     * Star Wars themed logging, and Docker Desktop integration.
+     * Star Wars themed logging.
      *
      * @param args command line arguments passed to the application
      */
     public static void main(String[] args) {
-        SpringApplication.run(JavaAgentShellMcpClientApplication.class, args);
+        SpringApplication.run(JavaAgentSimpleShellApplication.class, args);
     }
 }

--- a/examples-kotlin/pom.xml
+++ b/examples-kotlin/pom.xml
@@ -99,7 +99,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>enable-shell</id>
+            <id>enable-shell-mcp-client</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -123,7 +123,7 @@
             </build>
         </profile>
         <profile>
-            <id>enable-shell-mcp-client</id>
+            <id>enable-shell</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -139,7 +139,7 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <mainClass>com.embabel.example.KotlinAgentShellMcpClientApplicationKt</mainClass>
+                            <mainClass>com.embabel.example.KotlinAgentSimpleShellApplicationKt</mainClass>
                         </configuration>
                         <version>${spring-boot.version}</version>
                     </plugin>

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentShellApplication.kt
@@ -17,6 +17,7 @@ package com.embabel.example
 
 import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
+import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
@@ -43,6 +44,7 @@ import org.springframework.boot.runApplication
 )
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
+    mcpServers = [McpServers.DOCKER_DESKTOP, McpServers.DOCKER],
 )
 class KotlinAgentShellApplication
 

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentSimpleShellApplication.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/KotlinAgentSimpleShellApplication.kt
@@ -17,7 +17,6 @@ package com.embabel.example
 
 import com.embabel.agent.config.annotation.EnableAgents
 import com.embabel.agent.config.annotation.LoggingThemes
-import com.embabel.agent.config.annotation.McpServers
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
@@ -44,7 +43,6 @@ import org.springframework.boot.runApplication
 )
 @EnableAgents(
     loggingTheme = LoggingThemes.SEVERANCE,
-    mcpServers = [McpServers.DOCKER_DESKTOP, McpServers.DOCKER],
 )
 class KotlinAgentShellMcpClientApplication
 


### PR DESCRIPTION
This pull request reorganizes the Java and Kotlin example applications to clarify the distinction between simple shell applications and those with Docker MCP client integration. It updates Maven profiles, renames classes and files for clarity, and adjusts agent configuration annotations to better reflect each example's intended functionality.

**Example application separation and renaming:**

* Renamed `JavaAgentShellMcpClientApplication` to `JavaAgentSimpleShellApplication` and updated its documentation to clarify that it does not enable Docker MCP client integration, focusing on a straightforward shell example. [[1]](diffhunk://#diff-6cb5b0603df54cea959440a2751cb499885dd2da1d14aa220cca1f1f64270080L20-R35) [[2]](diffhunk://#diff-6cb5b0603df54cea959440a2751cb499885dd2da1d14aa220cca1f1f64270080L44-R61)
* Renamed `KotlinAgentShellMcpClientApplication.kt` to `KotlinAgentSimpleShellApplication.kt` and adjusted its configuration and documentation to match the Java example's separation. [[1]](diffhunk://#diff-3d7bf88f0be669fe43d6e240ca8f677b2b1351b87b8f9ec3b7e550404b2185a2L20) [[2]](diffhunk://#diff-3d7bf88f0be669fe43d6e240ca8f677b2b1351b87b8f9ec3b7e550404b2185a2L47)

**Maven profile and main class updates:**

* Swapped the IDs of the `enable-shell` and `enable-shell-mcp-client` Maven profiles in both `examples-java/pom.xml` and `examples-kotlin/pom.xml` to ensure the correct application is the default for each profile. [[1]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201L115-R115) [[2]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201L139-R139) [[3]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L102-R102) [[4]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L126-R126)
* Updated the `mainClass` property in the Maven build configuration to reference the newly renamed simple shell application classes. [[1]](diffhunk://#diff-b3e76c83254e5bc4bb2ffaf755b07148e5a3dc9a61bc0ae9f01009ab2ab8a201L155-R155) [[2]](diffhunk://#diff-dd315fe1795955607de74f099f7945e352ca32e2333f4c8dd6db9137788c8dd8L142-R142)

**Agent configuration adjustments:**

* Changed the logging theme in `JavaAgentShellApplication` to `STAR_WARS` and in `JavaAgentSimpleShellApplication` to `SEVERANCE` to better differentiate the examples. [[1]](diffhunk://#diff-e7c6448f16160e953786449c4e8a1733db839dde5d6e6b9bf6f48afbba9d77c7L45-R45) [[2]](diffhunk://#diff-6cb5b0603df54cea959440a2751cb499885dd2da1d14aa220cca1f1f64270080L44-R61)
* Updated `KotlinAgentShellApplication` to explicitly enable both `DOCKER_DESKTOP` and `DOCKER` MCP servers, while the simple shell variant omits MCP server integration. [[1]](diffhunk://#diff-501b7f811b9028c485831c2bc09baefaf068060a4a216630f86d0d0e0fcd3579R20) [[2]](diffhunk://#diff-501b7f811b9028c485831c2bc09baefaf068060a4a216630f86d0d0e0fcd3579R47) [[3]](diffhunk://#diff-3d7bf88f0be669fe43d6e240ca8f677b2b1351b87b8f9ec3b7e550404b2185a2L47)