### PR TITLE
Add Zipkin Console access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Make sure to run `docker compose up` in the project root to start Zipkin trace c
 ```bash
 docker compose up
 ```
+You should be able to access Zipkin Console: http://127.0.0.1:9411/zipkin/
 
 ### **MCP Server Mode**
 


### PR DESCRIPTION
This pull request updates the documentation to clarify how to access the Zipkin Console after starting the service. This helps users verify that Zipkin is running correctly.

Documentation improvements:

* Added instructions to access the Zipkin Console at `http://127.0.0.1:9411/zipkin/` in the `README.md` file.Added instruction for accessing Zipkin Console after starting Docker.