### PR TITLE
Align StarNewsFinder description with actual goal (#1616)

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/horoscope/StarNewsFinder.java
+++ b/examples-java/src/main/java/com/embabel/example/horoscope/StarNewsFinder.java
@@ -34,11 +34,12 @@ import java.util.stream.Collectors;
 
 
 /**
- * Find news based on a person's star sign
+ * Writes an amusing personalised writeup combining a person's horoscope
+ * and relevant current news stories.
  */
 @Agent(
         name = "JavaStarNewsFinder",
-        description = "Find news based on a person's star sign",
+        description = "Write an amusing personalised writeup combining a person's horoscope and current news stories",
         beanName = "javaStarNewsFinder")
 public class StarNewsFinder {
 

--- a/examples-kotlin/src/main/kotlin/com/embabel/example/horoscope/StarNewsFinder.kt
+++ b/examples-kotlin/src/main/kotlin/com/embabel/example/horoscope/StarNewsFinder.kt
@@ -76,7 +76,8 @@ data class Writeup(
 ) : HasContent
 
 /**
- * An agent that finds personalized news stories based on a person's star sign.
+ * An agent that writes a personalised, amusing writeup for a person by combining
+ * their daily horoscope with relevant current news stories.
  *
  * This agent demonstrates the workflow of:
  * 1. Extracting person information from user input
@@ -90,7 +91,7 @@ data class Writeup(
  * to define its capabilities and workflow.
  */
 @Agent(
-    description = "Find news based on a person's star sign",
+    description = "Write an amusing personalised writeup combining a person's horoscope and current news stories",
     scan = true,
     beanName = "KotlinStarNewsFinder",
 )
@@ -254,7 +255,7 @@ class StarNewsFinder(
     // The @AchievesGoal annotation indicates that completing this action
     // achieves the given goal, so the agent flow can be complete
     @AchievesGoal(
-        description = "Create an amusing writeup for the target person based on their horoscope",
+        description = "Create an amusing writeup for the target person based on their horoscope and current news stories",
         export = Export(
             remote = true,
             name = "StarNewsWriteup",


### PR DESCRIPTION
This pull request updates the documentation and descriptions for the `StarNewsFinder` agent in both the Java and Kotlin example projects. The main goal is to clarify that the agent now creates an amusing, personalized writeup by combining a person's horoscope with relevant current news stories, rather than just finding news based on a star sign.

**Documentation and description improvements:**

* Updated the class-level Javadoc in `StarNewsFinder.java` to specify that the agent writes an amusing personalized writeup combining horoscopes and current news stories, instead of only finding news by star sign.
* Updated the class-level KDoc and `@Agent` annotation in `StarNewsFinder.kt` to reflect the new functionality of writing a personalized, amusing writeup by combining horoscopes and news stories. [[1]](diffhunk://#diff-bd309c5571499dc48f50525514449a5f21bfc861f2032c3523eff9a2459cf61dL79-R80) [[2]](diffhunk://#diff-bd309c5571499dc48f50525514449a5f21bfc861f2032c3523eff9a2459cf61dL93-R94)
* Updated the `@AchievesGoal` annotation in `StarNewsFinder.kt` to clarify that the goal is to create an amusing writeup based on both horoscope and current news stories.