### PR TITLE
fix: update Subagent reference from GoatWriter to ReviseStoryUntilSatisfied

### DIFF
--- a/examples-java/src/main/java/com/embabel/example/handoff/Subagents.java
+++ b/examples-java/src/main/java/com/embabel/example/handoff/Subagents.java
@@ -53,7 +53,7 @@ class Subagents {
                 .withLlm(LlmOptions.withAutoLlm())
                 .withTools(
                         Subagent.ofClass(StarNewsFinder.class).consuming(StarPerson.class),
-                        Subagent.byName("GoatWriter").consuming(UserInput.class))
+                        Subagent.byName("ReviseStoryUntilSatisfied").consuming(UserInput.class))
                 .createObject("""
                                 The person has a strong interest in astrology and goats.
                                 Find 5 facts that will interest them, and return them as a list.


### PR DESCRIPTION
## Problem
Running Java examples with `x "Tell me something interesting"` fails with:

> Subagent with name 'GoatWriter' not found in platform default-agent-platform

The class was renamed from `GoatWriter` to `ReviseStoryUntilSatisfied`, but the `Subagent.byName()` reference in `handoff/Subagents.java:56` was never updated.

## Fix
- Changed `Subagent.byName("GoatWriter")` → `Subagent.byName("ReviseStoryUntilSatisfied")` 

Note: PR #132 attempts to fix the same issue by enabling bean scanning, but that alone is insufficient — `@Agent` on `ReviseStoryUntilSatisfied` has no explicit name attribute, so even with bean scanning it registers as "ReviseStoryUntilSatisfied", not "GoatWriter".

Fixes #77